### PR TITLE
Reorganiza documentacao e remove rename data.win -> game.droid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 /data/extracted-apk/
 /data/game.apk
 /data/prepared/
+/SteamFiles/
+/mods/PTBR/
+/mods/*.zip
+
+# Working checkout of the gh-pages branch (edited/pushed separately)
+/repo_tmp/
 
 # Generated builds and diagnostic output
 /artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,175 @@
+# CLAUDE.md
+
+Guia para trabalhar neste repositório com assistência de IA. Mantenha este arquivo atualizado:
+sempre que uma decisão importante for tomada, ou algo novo for implementado/mudado, atualize a
+seção relevante aqui (e o arquivo correspondente em `docs/`, se aplicável).
+
+## O que é este projeto
+
+Port não-oficial de **DELTARUNE (Capítulos 1–5)** para PlayStation Vita. Desde a v0.36, o projeto
+executa diretamente os dados do GameMaker da versão Windows/Steam usando uma implementação própria
+do [Butterscotch](https://github.com/ButterscotchRunner/Butterscotch) (reimplementação open source
+do runner do GameMaker: Studio), com renderização via
+[VitaGL](https://github.com/Rinnegatamante/vitaGL). Não há dependência de Android/APK — essa via foi
+avaliada e abandonada no início do projeto.
+
+Este repositório **não contém** assets ou dados comerciais de Deltarune. O usuário final precisa
+possuir a versão Steam legítima do jogo.
+
+## Documentação
+
+| Arquivo | Conteúdo |
+|---|---|
+| `CLAUDE.md` (este arquivo) | Visão geral, convenções, como colaborar no projeto |
+| `docs/arquitetura.md` | Componentes, pipeline de dados/build, decisões técnicas (VitaRenderer, cache de texturas, NPOT, troca de capítulo) |
+| `docs/roadmap.md` | Direção de médio/longo prazo |
+| `docs/backlog.md` | Tarefas concretas pendentes |
+| `docs/api.md` | Superfícies de integração: CLI dos scripts, opções de CMake, contrato de dados no device, builtins do GML |
+| `docs/changelog.md` | Histórico de mudanças por versão |
+| `docs/PROGRESS.md` | Narrativa do desenvolvimento — o que foi tentado, o que falhou, o que funcionou (YoYo Loader → SoLoader → Butterscotch nativo) |
+
+`README.md` é a documentação voltada ao usuário final (instalação, controles, screenshots). Não
+duplique conteúdo técnico lá — o README deve linkar para `docs/` quando precisar de profundidade.
+
+## Regra de manutenção deste arquivo
+
+Sempre que você (IA ou humano) tomar uma decisão arquitetural, mudar de abordagem, ou implementar
+algo novo relevante:
+
+1. Atualize `docs/arquitetura.md` se mudou algo estrutural (componente, pipeline, decisão técnica).
+2. Atualize `docs/roadmap.md` se mudou a direção planejada.
+3. Mova o item concluído de `docs/backlog.md` para `docs/changelog.md`.
+4. Atualize este `CLAUDE.md` se mudou uma convenção, comando, ou fato que outra IA precisaria saber
+   antes de mexer no projeto.
+
+Não crie novos arquivos `.md` soltos na raiz ou em `docs/` para documentar features pontuais — use a
+estrutura existente. Se um documento novo genuinamente não se encaixa em nenhum arquivo acima,
+pergunte ao usuário onde ele deveria viver antes de criar um novo.
+
+## Histórico resumido (contexto que evita retrabalho)
+
+O projeto começou com **YoYo Loader** e depois **SoLoader**, tentando rodar o APK Android no Vita.
+Essa abordagem chegava à LiveArea mas travava o Vita com uso alto de CPU/GPU — o hardware (512MB RAM,
+ARM Cortex-A9) não aguentava a camada de emulação do ambiente Android. **Essa via foi abandonada.**
+O código ainda existe em `src/legacy/` e `tools/yoyoloader-builder/` apenas como referência histórica
+— não é o pipeline ativo e não deve ser usado como base para novo trabalho.
+
+A abordagem atual lê `data.win` diretamente da instalação Windows/Steam, sem intermediário Android.
+Ver `docs/arquitetura.md` para os detalhes técnicos completos e `docs/PROGRESS.md` para a narrativa.
+
+## Estrutura do repositório (visão rápida)
+
+```
+src/butterscotch/    Motor GameMaker (fork vendored, VM + parser + renderer)
+src/vita-probe/       Ponte com o hardware do Vita (entrypoint, settings, vídeo, bordas)
+src/legacy/           Código morto (soloader, yoyoloader) — não usado no build ativo
+third_party/vitaGL-nosplash/  VitaGL vendored (fork "no splash")
+tools/                Utilitários de análise/modding (UndertaleModTool, xdelta, parse-core)
+scripts/              Pipeline de preparação de dados e build (.ps1)
+docs/                 Documentação técnica (ver tabela acima)
+```
+
+Detalhes completos em `docs/arquitetura.md`.
+
+### Onde fica o código dos patchers (não é óbvio)
+
+Os patchers (a ferramenta que o usuário final roda para gerar `VitaFiles/deltarune` a partir da
+instalação Steam) **não vivem em `src/` nem em `main`**:
+
+- **Patcher desktop** (32/64-bit, Python + PyInstaller): fonte em
+  `artifacts/Patcher/Build_Patch/src/` (`deltarune_vita_patcher.py`, `build_patch_data.py`,
+  `DeltaruneVitaPatcher.spec`). Fica dentro de `artifacts/`, que é gitignorado — é um diretório de
+  trabalho local, não algo versionado em `main`. `build_patch_data.py` gera `patch_data/manifest.json`
+  a partir de `data/prepared/...` (saída do `prepare-windows-data.ps1`) comparado com
+  `SteamFiles/v0.0.250/DELTARUNE`; roda-se via `Build_Patcher.bat`.
+- **Web Patcher**: fonte é a branch `gh-pages` do próprio repositório (`index.html`, `manifest.js`,
+  `mods_list.json`), não `main`. Se precisar editá-lo, dê `git fetch` e cheque essa branch — não
+  procure em `src/`.
+- Ambos os patchers leem `mods/mods_list.txt` (JSON com os links de download por mirror, hoje só
+  `PTBR`) como fonte única para a lista de mirrors de mods. Ver `docs/api.md` para o contrato.
+
+## Build e desenvolvimento
+
+Pipeline ativo (não use `Dockerfile`/`compose.yaml` da raiz — são stubs não conectados ao build real):
+
+```powershell
+# 1. Preparar dados a partir de uma instalação Steam legítima em SteamFiles/DELTARUNE
+powershell -ExecutionPolicy Bypass -File .\scripts\prepare-windows-data.ps1
+
+# 2. Build do VPK (Docker + VitaSDK, imagem atamanenko/vitasdk-softfp)
+powershell -ExecutionPolicy Bypass -File .\scripts\build-butterscotch-probe.ps1
+```
+
+Saída: `artifacts/current/Deltarune-v<versão>.vpk`.
+
+Ao lançar uma versão nova, mantenha sincronizados:
+- `PORT_BUILD_VERSION` em `src/vita-probe/source/playable_main.c`
+- `VERSION` em `vita_create_vpk` (`src/vita-probe/CMakeLists.txt`)
+- A entrada correspondente em `docs/changelog.md` (e no README, se for release pública)
+
+## Fluxo de contribuição e release
+
+Repositório: [github.com/WolffsRoom/DeltaruneVita](https://github.com/WolffsRoom/DeltaruneVita).
+
+Fluxo de trabalho (a partir desta decisão — antes disso, o projeto publicava apenas Pre-Releases
+avulsas, sem PR):
+
+1. Commits em branch de feature/fix.
+2. Abrir Pull Request — o diff completo fica visível no GitHub.
+3. Gerar o VPK local (`scripts/build-butterscotch-probe.ps1`) e testar no PS Vita real: performance,
+   gráficos, áudio, texto, regressões. Isso não substitui, é a mesma regra de "não validar correção
+   sem teste no Vita real" já descrita abaixo.
+4. Feedback no PR; ajustes; novo VPK; novo teste. Repete até aprovar.
+5. Merge do PR na `main`.
+6. Cria-se uma Pre-Release (pode agrupar vários PRs/ajustes de uma vez).
+
+### Convenção de nomes de VPK e release
+
+- **Build local durante iteração** (`artifacts/current/`): sufixo de letra depois da versão para
+  diferenciar builds da mesma versão numérica, ex.: `Deltarune-v0.63b.vpk`,
+  `Deltarune-v0.63c.vpk`, `Deltarune-v0.63d.vpk`. É só para uso local, não sobe assim.
+- **Pre-Release/Release publicada**: sem a letra — ex.: `Deltarune-v0.63.vpk`.
+- **Título da Pre-Release**: `DeltaruneVita v0.XX (Internal Development Build)`.
+- **Título da Release**: igual, mas sem o sufixo `(Internal Development Build)`.
+
+### Convenção de descrição de release
+
+Padrão observado nos releases publicados em
+[github.com/WolffsRoom/DeltaruneVita/releases](https://github.com/WolffsRoom/DeltaruneVita/releases):
+
+- **Pre-Release** (build interna): descrição em **português**, técnica e detalhada. Cada mudança
+  relevante explica problema → causa raiz → solução, citando símbolos do código (funções, constantes,
+  ex.: `vitaTextureCacheLimit`, `builtin_array_equals`) e referenciando issues do GitHub quando houver
+  (`WolffsRoom/DeltaruneVita#N`). Ao agrupar vários builds internos numa única Pre-Release, usar uma
+  seção do tipo "Compilado de Alterações das Builds Anteriores (vX.XX–vY.YY)" resumindo cada uma.
+- **Release pública**: descrição em **inglês**, voltada ao usuário final — cabeçalho/imagem, aviso de
+  instalação (ex.: "if you already have vX.XX installed, just install the new VPK"), uma tabela-resumo
+  de status por capítulo, e uma seção "Detailed Changelog Since vX.XX" em bullets, linkando para o
+  release anterior.
+
+Esse padrão espelha a convenção de idioma já usada no resto do projeto (código/commits em inglês,
+documentação técnica interna em português — ver seção de Convenções abaixo).
+
+Ao cortar uma Pre-Release/Release, é o momento de sincronizar `PORT_BUILD_VERSION`
+(`playable_main.c`) e `VERSION` (`vita-probe/CMakeLists.txt`) — não a cada PR individual, para
+evitar commits de bump isolados.
+
+## Convenções e coisas a não fazer
+
+- Não reintroduza a abordagem via APK/YoYo Loader/SoLoader — já foi tentada e abandonada por
+  limitação de hardware (ver histórico acima).
+- Não implemente builtins do GML especulativamente. Implemente apenas o que aparece como faltante
+  no log (`ux0:data/deltarune/deltarunevita/butterscotch-probe.log`), conforme reportado por testes
+  reais no hardware.
+- Não trate uma correção como validada sem teste no Vita real — dumps/logs de crash e comportamento
+  em hardware são a fonte de verdade, não suposição.
+- Não inclua nenhum asset, `data.win`, APK ou dado proprietário do jogo no repositório ou em commits.
+- Não misture `src/legacy/` com o pipeline ativo (`src/butterscotch/` + `src/vita-probe/`).
+- Idioma: código e nomes de variáveis em inglês; documentação e comentários de projeto majoritariamente
+  em português (refletindo o time atual); mantenha o idioma predominante de cada arquivo ao editá-lo.
+
+## Créditos e licenciamento
+
+- Butterscotch é derivado sob Mozilla Public License 2.0 (ver `LICENSE`).
+- VitaGL: fork de Rinnegatamante/vitaGL.
+- DELTARUNE © Toby Fox — este projeto não distribui arquivos comerciais do jogo.

--- a/artifacts/Patcher/Build_Patch/src/DeltaruneVitaPatcher.spec
+++ b/artifacts/Patcher/Build_Patch/src/DeltaruneVitaPatcher.spec
@@ -1,0 +1,14 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+root = Path(SPECPATH).parent
+a = Analysis(['deltarune_vita_patcher.py'], pathex=[], binaries=[],
+    datas=[(str(root / 'patch_data'), 'patch_data'), (str(root.parent.parent.parent / 'mods' / 'mods_list.txt'), '.')],
+    hiddenimports=['bsdiff4'], hookspath=[], hooksconfig={}, runtime_hooks=[],
+    excludes=[], noarchive=False, optimize=0)
+pyz = PYZ(a.pure)
+exe = EXE(pyz, a.scripts, a.binaries, a.datas, [], name='DeltaruneVitaPatcher',
+    debug=False, bootloader_ignore_signals=False, strip=False, upx=True,
+    console=True, disable_windowed_traceback=False, argv_emulation=False,
+    target_arch=None, codesign_identity=None, entitlements_file=None,
+    icon=str(root / 'icon.ico'))

--- a/artifacts/Patcher/Build_Patch/src/build_patch_data.py
+++ b/artifacts/Patcher/Build_Patch/src/build_patch_data.py
@@ -1,0 +1,138 @@
+"""Create the DELTARUNE Vita redistributable patch bundle from Steam files."""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import bsdiff4
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[4]
+STEAM_ROOT = ROOT / "SteamFiles" / "v0.0.250" / "DELTARUNE"
+DEV_ROOT = ROOT / "data" / "prepared" / "deltarune" / "deltarunevita"
+PATCH_ROOT = ROOT / "artifacts" / "Patcher" / "patch_data"
+PORT_VERSION = "0.63"
+
+
+def prepare_vita_output(source: Path, relative: Path, temporary: Path) -> Path:
+    """Apply PC-side conversions that should not be repeated on the Vita."""
+    parts = tuple(part.lower() for part in relative.parts)
+    if "borders" not in parts or source.suffix.lower() != ".png":
+        return source
+    with Image.open(source) as image:
+        if image.size[0] <= 960 and image.size[1] <= 544:
+            return source
+        target = temporary / "optimized" / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        image.convert("RGBA").resize((960, 544), Image.Resampling.LANCZOS).save(
+            target, format="PNG", optimize=True, compress_level=9
+        )
+        return target
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def expected_source(relative: Path) -> Path | None:
+    parts = relative.parts
+    if not parts or parts[0].lower() != "deltarunevita":
+        return None
+    inner = Path(*parts[1:])
+    if inner.parts and inner.parts[0].lower() == "music":
+        return Path("mus", *inner.parts[1:])
+    if inner.parts and inner.parts[0].lower().startswith("chapter"):
+        chapter = inner.parts[0].lower()
+        tail = Path(*inner.parts[1:])
+        if chapter == "chapter0":
+            return tail
+        number = chapter.removeprefix("chapter")
+        return Path(f"chapter{number}_windows", tail)
+    return inner
+
+
+def main() -> None:
+    if not (STEAM_ROOT / "DELTARUNE.exe").is_file() or not (STEAM_ROOT / "data.win").is_file():
+        raise SystemExit(f"Steam installation not found in: {STEAM_ROOT}")
+    if not DEV_ROOT.is_dir():
+        raise SystemExit(f"Prepared Vita files not found in: {DEV_ROOT}")
+
+    steam_files = sorted(p for p in STEAM_ROOT.rglob("*") if p.is_file())
+    print(f"Indexing {len(steam_files)} Steam files...")
+    hashes: dict[str, list[Path]] = {}
+    for path in steam_files:
+        hashes.setdefault(sha256_file(path), []).append(path)
+
+    if PATCH_ROOT.exists():
+        shutil.rmtree(PATCH_ROOT)
+    (PATCH_ROOT / "patches").mkdir(parents=True)
+
+    records: list[dict[str, object]] = []
+    required: dict[str, dict[str, object]] = {}
+    vita_files = sorted(p for p in DEV_ROOT.rglob("*") if p.is_file())
+    with tempfile.TemporaryDirectory() as td:
+        temp = Path(td)
+        for number, output in enumerate(vita_files):
+            relative = output.relative_to(DEV_ROOT)
+            prepared_output = prepare_vita_output(output, relative, temp)
+            output_hash = sha256_file(prepared_output)
+            source: Path | None = None
+
+            identical = hashes.get(output_hash)
+            if identical:
+                preferred = expected_source(relative)
+                preferred_abs = STEAM_ROOT / preferred if preferred else None
+                source = preferred_abs if preferred_abs in identical else identical[0]
+                mode = "copy"
+            else:
+                candidate = expected_source(relative)
+                candidate_abs = STEAM_ROOT / candidate if candidate else None
+                source = candidate_abs if candidate_abs and candidate_abs.is_file() else None
+                mode = "patch"
+
+            source_rel = source.relative_to(STEAM_ROOT).as_posix() if source else None
+            record: dict[str, object] = {
+                "output": relative.as_posix(), "source": source_rel,
+                "size": prepared_output.stat().st_size, "sha256": output_hash, "mode": mode,
+            }
+            if source:
+                required[source_rel] = {"size": source.stat().st_size, "sha256": sha256_file(source)}
+            if mode == "patch":
+                patch_name = f"{number:04d}.bsdiff"
+                old_path = temp / "old"
+                if source:
+                    shutil.copyfile(source, old_path)
+                else:
+                    old_path.write_bytes(b"")
+                bsdiff4.file_diff(str(old_path), str(prepared_output), str(PATCH_ROOT / "patches" / patch_name))
+                record["patch"] = patch_name
+            records.append(record)
+            if (number + 1) % 25 == 0 or number + 1 == len(vita_files):
+                print(f"  processed {number + 1}/{len(vita_files)}")
+
+    manifest = {
+        "format": 3, "game": "DELTARUNE", "port_version": PORT_VERSION,
+        "output_folder": "deltarune", "steam_folder": "DELTARUNE",
+        "optimizations": {"console_borders": "RGBA PNG 960x544"},
+        "required_sources": required, "files": records,
+    }
+    (PATCH_ROOT / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    (PATCH_ROOT / "manifest.js").write_text(
+        "const manifestData = " + json.dumps(manifest, indent=2, ensure_ascii=False) + ";\n", encoding="utf-8"
+    )
+    patch_size = sum(p.stat().st_size for p in (PATCH_ROOT / "patches").glob("*"))
+    print(f"Created {len(records)} records and {patch_size / 1024 / 1024:.1f} MiB of binary patches.")
+
+
+if __name__ == "__main__":
+    main()

--- a/artifacts/Patcher/Build_Patch/src/deltarune_vita_patcher.py
+++ b/artifacts/Patcher/Build_Patch/src/deltarune_vita_patcher.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+"""DELTARUNE PS Vita data patcher by WolffsRoom."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+import bsdiff4
+
+VERSION = "0.63"
+LANGUAGES = [
+    ("English", "EN"), ("Portugues (Brasil)", "PT"), ("Espanol", "ES"),
+    ("Francais", "FR"), ("Portugues (Portugal)", "PTPT"), ("Italiano", "IT"),
+    ("Russian", "RU"), ("Japanese", "JP"),
+]
+
+TR = {
+    "EN": dict(note="This changes only the language of this program. It does not change the game's language.",
+        instruction="Copy an original, unmodified DELTARUNE Steam installation into SteamFiles.",
+        output="The output will be created in VitaFiles\\deltarune.", found="Steam installation found",
+        missing="No valid DELTARUNE Steam installation was found in SteamFiles.", confirm="Start generating VitaFiles?",
+        yes="Y", cancelled="Operation cancelled.", verify="Verifying Steam files", incompatible="Incompatible or modified Steam file",
+        generating="Generating Vita data", checkfail="Output verification failed", success="SUCCESS! All files were generated and verified.",
+        copy="Copy the 'deltarune' folder to ux0:data/ on the PS Vita.", error="ERROR", close="Press ENTER to close..."),
+    "PT": dict(note="Isso altera somente o idioma deste programa. Nao altera o idioma do jogo.",
+        instruction="Copie uma instalacao original e sem modificacoes do DELTARUNE da Steam para SteamFiles.",
+        output="A saida sera criada em VitaFiles\\deltarune.", found="Instalacao Steam encontrada",
+        missing="Nenhuma instalacao valida do DELTARUNE foi encontrada em SteamFiles.", confirm="Iniciar a geracao do VitaFiles?",
+        yes="S", cancelled="Operacao cancelada.", verify="Verificando arquivos da Steam", incompatible="Arquivo Steam incompativel ou modificado",
+        generating="Gerando dados do Vita", checkfail="Falha ao verificar a saida", success="SUCESSO! Todos os arquivos foram gerados e verificados.",
+        copy="Copie a pasta 'deltarune' para ux0:data/ no PS Vita.", error="ERRO", close="Pressione ENTER para fechar..."),
+    "ES": dict(note="Esto solo cambia el idioma de este programa. No cambia el idioma del juego.",
+        instruction="Copia una instalacion original de DELTARUNE de Steam dentro de SteamFiles.", output="La salida se creara en VitaFiles\\deltarune.",
+        found="Instalacion de Steam encontrada", missing="No se encontro una instalacion valida de DELTARUNE en SteamFiles.",
+        confirm="Iniciar la generacion de VitaFiles?", yes="S", cancelled="Operacion cancelada.", verify="Verificando archivos de Steam",
+        incompatible="Archivo de Steam incompatible o modificado", generating="Generando datos de Vita", checkfail="Error al verificar la salida",
+        success="EXITO! Todos los archivos fueron generados y verificados.", copy="Copia la carpeta 'deltarune' a ux0:data/ en PS Vita.", error="ERROR", close="Pulsa ENTER para cerrar..."),
+    "FR": dict(note="Ceci change uniquement la langue de ce programme, pas celle du jeu.",
+        instruction="Copiez une installation Steam originale de DELTARUNE dans SteamFiles.", output="La sortie sera creee dans VitaFiles\\deltarune.",
+        found="Installation Steam trouvee", missing="Aucune installation DELTARUNE valide trouvee dans SteamFiles.", confirm="Commencer la creation de VitaFiles ?",
+        yes="O", cancelled="Operation annulee.", verify="Verification des fichiers Steam", incompatible="Fichier Steam incompatible ou modifie",
+        generating="Creation des donnees Vita", checkfail="Echec de verification de la sortie", success="SUCCES ! Tous les fichiers ont ete crees et verifies.",
+        copy="Copiez le dossier 'deltarune' vers ux0:data/ sur PS Vita.", error="ERREUR", close="Appuyez sur ENTREE pour fermer..."),
+    "PTPT": dict(note="Isto altera apenas o idioma deste programa. Nao altera o idioma do jogo.",
+        instruction="Copie uma instalacao Steam original do DELTARUNE para SteamFiles.", output="A saida sera criada em VitaFiles\\deltarune.",
+        found="Instalacao Steam encontrada", missing="Nao foi encontrada uma instalacao DELTARUNE valida em SteamFiles.", confirm="Iniciar a criacao de VitaFiles?",
+        yes="S", cancelled="Operacao cancelada.", verify="A verificar ficheiros Steam", incompatible="Ficheiro Steam incompativel ou modificado",
+        generating="A criar dados Vita", checkfail="Falha ao verificar a saida", success="SUCESSO! Todos os ficheiros foram criados e verificados.",
+        copy="Copie a pasta 'deltarune' para ux0:data/ na PS Vita.", error="ERRO", close="Prima ENTER para fechar..."),
+    "IT": dict(note="Questo cambia solo la lingua del programma, non quella del gioco.",
+        instruction="Copia un'installazione Steam originale di DELTARUNE in SteamFiles.", output="I file verranno creati in VitaFiles\\deltarune.",
+        found="Installazione Steam trovata", missing="Nessuna installazione DELTARUNE valida trovata in SteamFiles.", confirm="Avviare la generazione di VitaFiles?",
+        yes="S", cancelled="Operazione annullata.", verify="Verifica dei file Steam", incompatible="File Steam incompatibile o modificato",
+        generating="Generazione dati Vita", checkfail="Verifica dei file generati fallita", success="SUCCESSO! Tutti i file sono stati generati e verificati.",
+        copy="Copia la cartella 'deltarune' in ux0:data/ sulla PS Vita.", error="ERRORE", close="Premi INVIO per chiudere..."),
+    "RU": dict(note="Eto menyaet tolko yazyk programmy, no ne yazyk igry.", instruction="Skopiruyte originalnuyu Steam-versiyu DELTARUNE v SteamFiles.",
+        output="Rezultat budet sozdan v VitaFiles\\deltarune.", found="Steam-versiya naydena", missing="V SteamFiles net podhodyashchey versii DELTARUNE.",
+        confirm="Nachat sozdanie VitaFiles?", yes="Y", cancelled="Operatsiya otmenena.", verify="Proverka faylov Steam", incompatible="Fayl Steam izmenyon ili nesovmestim",
+        generating="Sozdanie dannyh Vita", checkfail="Oshibka proverki rezultata", success="USPEH! Vse fayly sozdany i provereny.",
+        copy="Skopiruyte papku 'deltarune' v ux0:data/ na PS Vita.", error="OSHIBKA", close="Nazhmite ENTER dlya vyhoda..."),
+    "JP": dict(note="Kore wa kono puroguramu no gengo dake wo henkou shimasu. Geemu no gengo wa kawarimasen.",
+        instruction="Steam no seiki DELTARUNE foruda wo SteamFiles ni kopii shite kudasai.", output="VitaFiles\\deltarune ni sakusei shimasu.",
+        found="Steam foruda ga mitsukarimashita", missing="SteamFiles ni DELTARUNE ga arimasen.", confirm="VitaFiles wo sakusei shimasu ka?",
+        yes="Y", cancelled="Kyanseru shimashita.", verify="Steam fairu kakunin-chu", incompatible="Steam fairu ga chigaimasu",
+        generating="Vita deeta sakusei-chu", checkfail="Shutsuryoku kakunin ni shippai", success="SEIKOU! Subete no fairu wo sakusei kakunin shimashita.",
+        copy="'deltarune' foruda wo PS Vita no ux0:data/ ni kopii shite kudasai.", error="ERAA", close="ENTER de shuuryou..."),
+}
+
+
+def app_dir() -> Path:
+    return Path(sys.executable if getattr(sys, "frozen", False) else __file__).resolve().parent
+
+
+def resource(relative: str) -> Path:
+    return Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent)) / relative
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""): h.update(block)
+    return h.hexdigest()
+
+
+def safe_path(value: str) -> Path:
+    posix = PurePosixPath(value)
+    if posix.is_absolute() or ".." in posix.parts: raise ValueError("Invalid path in patch manifest")
+    return Path(*posix.parts)
+
+
+def find_steam(text: dict) -> Path:
+    base = app_dir() / "SteamFiles"
+    for candidate in (base / "DELTARUNE", base):
+        if (candidate / "DELTARUNE.exe").is_file() and (candidate / "data.win").is_file(): return candidate
+    raise ValueError(text["missing"])
+
+
+def verify_steam(steam: Path, manifest: dict, text: dict) -> None:
+    sources = manifest.get("required_sources", {})
+    for index, (relative, expected) in enumerate(sources.items(), 1):
+        source = steam / safe_path(relative)
+        if not source.is_file() or source.stat().st_size != expected["size"] or sha256(source) != expected["sha256"]:
+            raise ValueError(f"{text['incompatible']}: {relative}")
+        print(f"\r  {text['verify']}... {index * 100 // len(sources):3d}%", end="", flush=True)
+    print()
+
+
+def generate(steam: Path, manifest: dict, text: dict) -> Path:
+    destination = app_dir() / "VitaFiles" / manifest["output_folder"]
+    temporary = destination.with_name(destination.name + ".tmp")
+    shutil.rmtree(temporary, ignore_errors=True)
+    temporary.mkdir(parents=True)
+    files = manifest["files"]
+    try:
+        for index, record in enumerate(files, 1):
+            output = temporary / safe_path(record["output"])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            source_name = record.get("source")
+            source = steam / safe_path(source_name) if source_name else None
+            if record["mode"] == "copy":
+                if source is None: raise ValueError(record["output"])
+                shutil.copyfile(source, output)
+            else:
+                old = source if source else temporary / ".empty"
+                if source is None: old.write_bytes(b"")
+                bsdiff4.file_patch(str(old), str(output), str(resource("patch_data/patches") / record["patch"]))
+                if source is None: old.unlink(missing_ok=True)
+            if output.stat().st_size != record["size"] or sha256(output) != record["sha256"]:
+                raise ValueError(f"{text['checkfail']}: {record['output']}")
+            print(f"\r  {text['generating']}... {index * 100 // len(files):3d}%", end="", flush=True)
+        print()
+        shutil.rmtree(destination, ignore_errors=True)
+        os.replace(temporary, destination)
+        validate_and_describe_output(destination, manifest)
+        return destination
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def validate_and_describe_output(destination: Path, manifest: dict) -> None:
+    """Validate streamable audio and record PC-side preparation details."""
+    ogg_files = list(destination.rglob("*.ogg"))
+    for audio in ogg_files:
+        with audio.open("rb") as stream:
+            if stream.read(4) != b"OggS":
+                raise ValueError(f"Invalid OGG stream: {audio.relative_to(destination)}")
+    borders = list((destination / "deltarunevita" / "borders").glob("*.png"))
+    report = {
+        "patcher_version": VERSION,
+        "port_version": manifest.get("port_version"),
+        "steam_version": "v0.0.250",
+        "validated_ogg_files": len(ogg_files),
+        "prepared_console_borders": len(borders),
+        "console_border_size": "960x544",
+    }
+    report_path = destination / "deltarunevita" / "patcher-report.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+def draw_header() -> None:
+    print("=" * 66)
+    print("               DELTARUNE - PS VITA PATCHER")
+    print(f"                         v{VERSION}")
+    print("                    Patcher by WolffsRoom")
+    print("=" * 66)
+
+
+def choose_language() -> str:
+    draw_header()
+    print("\n  SELECT LANGUAGE / SELECIONE O IDIOMA\n")
+    for index, (name, _) in enumerate(LANGUAGES, 1): print(f"    [{index}] {name}")
+    print("    [0] Exit / Sair")
+    print("\n  NOTE: This changes only this program's language, not the game.")
+    print("  NOTA: Isso altera somente o idioma deste programa, nao do jogo.\n")
+    while True:
+        choice = input("  > ").strip()
+        if choice == "0": return ""
+        if choice.isdigit() and 1 <= int(choice) <= len(LANGUAGES): return LANGUAGES[int(choice) - 1][1]
+        print("  Invalid option / Opcao invalida.")
+
+
+
+def get_mods_list() -> dict:
+    try:
+        path = resource("mods_list.txt")
+        if path.is_file():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    # Fallback to hardcoded list
+    return {
+        "PTBR": {
+            "Mediafire": "https://download1472.mediafire.com/wq1sfbskzyhgPzEezrIa5jdDfX9Mut7e3yehfMKMTT5tXxRNA5X_1-Kh9O0LRfl6I_nVWA7RB9ZhyhfAEz2yf6qjBOpUN5bCodQ-juY-TV7E1WysP0VfsJh20Es2vJVICDQMP5VCRqMo65PP9SBEzMASqy0wHF_0Ma69YLJxga4KQUg/4ildqbqja3ehuq2/PTBR.zip",
+            "Mega": "https://mega.nz/file/ExcDiC6B#1pqrFjmz2-xaEiQ0SWOaa13N18k9sWevwHWIww21b8Q",
+            "Google Drive": "https://drive.google.com/uc?export=download&id=1LCT2kD-WQpPQO3dAeIldXBUn2j3c0m9d",
+            "Archive": "https://archive.org/download/ptbr_20260725/PTBR.zip"
+        }
+    }
+
+
+def choose_mirror(mods_list: dict) -> str:
+    print("\n  SELECT DOWNLOAD MIRROR FOR PTBR MOD / SELECIONE O SERVIDOR DE DOWNLOAD DA TRADUÇÃO:\n")
+    mirrors = list(mods_list["PTBR"].keys())
+    for index, name in enumerate(mirrors, 1):
+        print(f"    [{index}] {name}")
+    print("\n  Default is [4] Archive.org / O padrão é [4] Archive.org")
+    while True:
+        choice = input("  > ").strip()
+        if not choice: return mirrors[3] # default Archive
+        if choice.isdigit() and 1 <= int(choice) <= len(mirrors):
+            return mirrors[int(choice) - 1]
+        print("  Invalid option / Opção inválida.")
+
+
+def download_mod(url: str, dest: Path) -> None:
+    print(f"  Downloading translation from {url}...")
+    req = urllib.request.Request(
+        url,
+        headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'}
+    )
+    with urllib.request.urlopen(req) as response, open(dest, 'wb') as out_file:
+        length = response.getheader('content-length')
+        if length:
+            length = int(length)
+            block_size = 64 * 1024
+            downloaded = 0
+            while True:
+                buffer = response.read(block_size)
+                if not buffer:
+                    break
+                out_file.write(buffer)
+                downloaded += len(buffer)
+                print(f"\r  Downloading... {downloaded * 100 // length:3d}%", end="", flush=True)
+            print()
+        else:
+            out_file.write(response.read())
+
+
+def extract_mod(zip_path: Path, dest_dir: Path) -> None:
+    print("  Extracting translation...")
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        has_ptbr_root = any(name.lower().startswith("ptbr/") or name.lower().startswith("ptbr\\") for name in zip_ref.namelist())
+        
+        for member in zip_ref.infolist():
+            if member.is_dir(): continue
+            
+            # Determine destination path
+            if has_ptbr_root:
+                target_path = dest_dir / member.filename
+            else:
+                target_path = dest_dir / "PTBR" / member.filename
+                
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with zip_ref.open(member) as source, open(target_path, "wb") as target:
+                shutil.copyfileobj(source, target)
+
+
+def main() -> int:
+    os.system("chcp 65001 >nul")
+    os.system("title DELTARUNE - PS Vita Patcher")
+    os.system("color 0A")
+    lang = choose_language()
+    if not lang: return 0
+    text = TR[lang]
+    os.system("cls")
+    draw_header()
+    print(f"\n  NOTE: {text['note']}\n")
+    print(f"  {text['instruction']}")
+    print(f"  {text['output']}\n")
+    try:
+        manifest = json.loads(resource("patch_data/manifest.json").read_text(encoding="utf-8"))
+        steam = find_steam(text)
+        print(f"  {text['found']}: {steam}")
+        answer = input(f"  {text['confirm']} [{text['yes']}/N]: ").strip().upper()
+        if answer != text["yes"]: print(f"\n  {text['cancelled']}"); return 0
+        verify_steam(steam, manifest, text)
+        result = generate(steam, manifest, text)
+        
+        # If the user is running in Portuguese, download the translation files
+        if lang in ("PT", "PTPT"):
+            try:
+                mods_list = get_mods_list()
+                chosen_mirror = choose_mirror(mods_list)
+                url = mods_list["PTBR"][chosen_mirror]
+                temp_zip = app_dir() / "PTBR.zip"
+                try:
+                    download_mod(url, temp_zip)
+                    extract_mod(temp_zip, result / "deltarunevita" / "mods")
+                finally:
+                    if temp_zip.is_file():
+                        temp_zip.unlink()
+            except Exception as e:
+                print(f"\n  Warning: Could not automatically download translation mod: {e}")
+                print("  You can still manually download it and place it in deltarunevita/mods.")
+
+        print(f"\n  {text['success']}\n  {result}\n\n  {text['copy']}")
+        code = 0
+    except Exception as exc:
+        print(f"\n  {text['error']}: {exc}")
+        code = 1
+    input(f"\n  {text['close']}")
+    return code
+
+
+if __name__ == "__main__": raise SystemExit(main())

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,33 +1,59 @@
-# Desenvolvimento do port
+# Progresso do port
 
-## Primeiros testes
+## Primeiras tentativas
 
-O projeto começou com YoYo Loader e uma base de SoLoader. Esses builds validaram o VPK, a LiveArea e a organização dos dados, mas o Vita congelava com CPU e GPU em 100%. Logs por etapa mostraram que seria necessário controlar diretamente o carregamento, a memória e o renderer.
+O trabalho começou com YoYo Loader e uma base de SoLoader. O jogo chegava à LiveArea, mas congelava o Vita com uso alto de CPU e GPU. Foram adicionados logs por etapa para separar problemas do carregador, do parser e da renderização.
 
-## Mudança para Butterscotch
+O YoYo Loader serviu para validar a organização dos arquivos e os requisitos do Vita, mas não foi suficiente para executar esta versão do runner do GameMaker. A partir daí o port mudou para o Butterscotch.
 
-O Butterscotch tornou possível interpretar o bytecode GameMaker dos seis pacotes: o seletor (`chapter0`) e os capítulos 1 a 5. O port ganhou um executável próprio, filesystem separado para assets e saves, entrada do Vita e um log persistente.
+## Leitura dos capítulos
 
-O carregamento de salas e texturas passou a ser sob demanda. Isso foi essencial para capítulos maiores, que ultrapassavam o limite normal de memória do Vita.
+Os arquivos `chapter0.wad` até `chapter5.wad` foram analisados e o `assets/game.droid` de cada capítulo passou a ser preparado separadamente. O parser do Butterscotch conseguiu ler os principais chunks do GameMaker, incluindo salas, objetos, scripts, fontes, páginas de textura e bytecode.
 
-## Renderer do Vita
+O carregamento passou a ser preguiçoso para salas e texturas. Isso evitou colocar todos os dados dos capítulos maiores na memória de uma vez.
 
-Os primeiros quadros falhavam por três motivos principais: pool gráfico pequeno, stack insuficiente e uso de OpenGL imediato pelo renderer legado.
+## Runner jogável
 
-O VPK passou a usar o perfil ampliado de memória, stack principal de 4 MiB e pool VitaGL de 64 MiB. O renderer legado foi adaptado de `glBegin/glEnd` para client arrays e `glDrawArrays`, cobrindo sprites, fontes, tiles, primitivas e surfaces. Esse trabalho levou o projeto de páginas de textura isoladas ao menu e depois ao gameplay.
+Foi criado um executável Vita com:
 
-## Capítulos jogáveis
+- VM do Butterscotch;
+- loop de step e draw;
+- filesystem separado para dados e saves;
+- áudio temporariamente substituído por um backend vazio;
+- teclado virtual mapeado para os botões do Vita;
+- log persistente em `ux0:data/deltarune/deltarunevita`.
 
-O seletor original solicita outro executável por meio de `game_change`. No Vita, a troca foi implementada como um reinício limpo do próprio eboot com o capítulo solicitado. Dessa forma os recursos do capítulo anterior são liberados antes do próximo carregamento.
+O seletor chegou a criar a primeira sala, mas os primeiros builds caíam antes do primeiro quadro.
 
-Após correções de builtins, surfaces e inicialização gráfica, os capítulos 1 e 2 foram os primeiros a rodar. O mesmo caminho foi estendido aos capítulos 3, 4 e 5. A opção Change Chapter dentro do jogo retorna ao seletor em vez de encerrar o aplicativo.
+## Diagnóstico dos crashes
 
-## Experiência no Vita
+Os dumps mostraram três problemas principais:
 
-O backend de áudio OpenAL foi ativado e o mapeamento foi ajustado para X confirmar e Círculo cancelar. SELECT abre um menu próprio do port, com touch, idioma/mod, volume e tela. Os controles touch usam sprites já existentes no jogo.
+1. Pool gráfico pequeno para as primeiras páginas de textura.
+2. Stack padrão de 256 KiB insuficiente durante a preparação dos shaders.
+3. Uso do modo imediato de OpenGL pelo renderer legado.
 
-Como as cenas e bordas dinâmicas variam entre capítulos, foi criado um ajuste de posição e zoom com contorno visível. A configuração fica salva em `ux0:data/deltarune/config.ini`.
+O pool do VitaGL passou para 64 MiB e a stack principal para 4 MiB. O compilador runtime de shaders foi colocado em modo conservador durante os testes.
 
-## Situação atual
+## VitaRenderer
 
-A v0.31 é um port jogável e viável no Vita real. O trabalho futuro é de compatibilidade e acabamento: corrigir efeitos específicos que ainda se comportem diferente, melhorar desempenho em salas pesadas, refinar bordas dinâmicas e ampliar a compatibilidade com mods.
+O ponto decisivo foi substituir as chamadas `glBegin/glEnd` do renderer legado por client arrays e `glDrawArrays`. Primeiro foram migrados sprites e retângulos. Depois foi criada uma ponte para converter também fontes, tiles, linhas, triângulos e blits de surfaces.
+
+Na versão `00.17`, o seletor de capítulos apareceu e funcionou no Vita real. O menu respondeu aos controles e as páginas de textura de 256×256 e 2048×2048 foram carregadas com sucesso.
+
+## Troca de capítulos
+
+O seletor usa a função `game_change` do GameMaker. O Butterscotch registrava a solicitação, mas o main do Vita não tratava a mudança, por isso a tela ficava em `Initializing Chapter`.
+
+A versão `00.18` grava o capítulo solicitado, reinicia o próprio eboot e abre diretamente o `game.droid` correspondente. O reinício libera os recursos do seletor antes de carregar capítulos que passam de 200 MB.
+
+O `param.sfo` também passou a usar `ATTRIBUTE2=12`. O campo foi conferido no VPK final.
+
+## Próximos pontos
+
+- validar a entrada nos capítulos 1 a 5;
+- corrigir builtins ainda não implementados conforme aparecerem no log;
+- medir o uso de memória nos capítulos maiores;
+- implementar áudio;
+- revisar surfaces, shaders e efeitos usados durante o gameplay;
+- testar saves e transições entre capítulos.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,83 @@
+# API interna / superfícies de integração
+
+Este projeto não expõe uma API HTTP. "API" aqui significa as **superfícies de integração
+estáveis** do projeto: os pontos que scripts, build e runtime usam para se comunicar entre si e
+que não devem mudar sem atualizar todos os consumidores. Trate como o "contrato" entre as partes
+do pipeline descrito em [arquitetura.md](arquitetura.md).
+
+## CLI dos scripts (PowerShell)
+
+| Script | Uso | Entrada | Saída |
+|---|---|---|---|
+| `scripts/prepare-windows-data.ps1` | Preparar dados a partir da instalação Steam legítima | `SteamFiles/DELTARUNE/` | `data/prepared/deltarune/deltarunevita/` |
+| `scripts/prepare-vita-mods.ps1` | Empacotar mods (ex.: tradução PT-BR) | `mods/PTBR/` | mesclado em `data/prepared/...` |
+| `scripts/build-butterscotch-probe.ps1` | Build ativo do VPK (Docker + VitaSDK) | fontes em `src/`, dados preparados | `artifacts/current/Deltarune-v<versão>.vpk` |
+| `scripts/build-deltarune.ps1` | **Legado** — build do SoLoader antigo | `src/legacy/soloader` | não é o pipeline atual |
+| `scripts/prepare-deltarune-data.ps1` | **Legado** — validação de assets extraídos de APK | — | ligado à abordagem Android abandonada |
+
+Todos rodam via `powershell -ExecutionPolicy Bypass -File .\scripts\<nome>.ps1`.
+
+## Opções de build (CMake, `src/vita-probe/CMakeLists.txt`)
+
+- `PLAYABLE_RUNNER` (padrão `ON`) — build completo do runner Butterscotch para Vita. É o alvo usado
+  em produção.
+- `VITAGL_PROBE` (padrão `OFF`) — build isolado de diagnóstico do VitaGL, sem o runner do jogo.
+- Se nenhuma das duas estiver ativa, cai no alvo mínimo (`source/main.c`), um parser de `data.win`
+  com saída em `debugScreen.c`, usado só para depuração de baixo nível.
+
+Metadados fixos do pacote:
+- `TITLE ID`: `DLTVITA01`
+- `param.sfo`: `ATTRIBUTE2=12`
+- `VERSION` do VPK (CMake) deve ser mantida em sincronia com `PORT_BUILD_VERSION` em
+  `src/vita-probe/source/playable_main.c`.
+
+## Layout de dados no dispositivo (contrato com o runtime)
+
+```text
+ux0:data/deltarune/
+├── config.ini                          # settings persistidos (vídeo/áudio/controles)
+├── save/                                # saves do jogo
+└── deltarunevita/
+    ├── chapter0/ … chapter5/            # data.win (sem rename) + assets por capítulo
+    ├── music/
+    ├── borders/
+    └── mods/                            # mods preparados (ex.: PTBR), um por capítulo
+```
+
+- `config.ini` é lido/escrito por `src/vita-probe/source/vita_settings.c`
+  (`SETTINGS_PATH = "ux0:data/deltarune/config.ini"`).
+- Log de execução: `ux0:data/deltarune/deltarunevita/butterscotch-probe.log` — é o principal
+  artefato para diagnosticar crashes e builtins faltantes; sempre peça esse arquivo ao reportar bugs.
+- Diretórios de save de versões antigas (`v0.53`–`v0.56`, mixed-case) são migrados automaticamente
+  na inicialização (ver comentário em `playable_main.c:357`) — ao mexer nesse código, preserve a
+  migração para não quebrar saves de usuários antigos.
+
+## Superfície de builtins do GML (Butterscotch)
+
+`src/butterscotch/src/vm_builtins.c` implementa as funções builtin do GameMaker Language que o
+bytecode de Deltarune chama. Builtins não implementados aparecem no log em tempo de execução — a
+prática do projeto é **só implementar o que aparece no log**, não tentar prever builtins que talvez
+nunca sejam usados (evita trabalho especulativo e superfície de bugs desnecessária).
+
+## Troca de capítulo (runtime → runtime)
+
+O seletor de capítulos chama `game_change` (builtin do GameMaker). O `vita-probe` intercepta essa
+solicitação, grava o capítulo pedido em disco e **reinicia o próprio eboot**, que em seguida lê o
+`data.win` do capítulo salvo. Esse é o único mecanismo de troca de capítulo — não existe hot-swap
+de VM em memória.
+
+## Mods: mirrors de download e mapeamento de arquivos
+
+`mods/mods_list.txt` é a fonte única de verdade para os links de download de mods de idioma (hoje só
+`PTBR`). É um JSON `{"<mod>": {"<nome do mirror>": "<url>"}}`; a ordem das chaves define a ordem
+exibida nos patchers. Consumido por três lugares, que devem ficar sincronizados com esse arquivo:
+
+- **Patcher desktop** (`deltarune_vita_patcher.py`, `get_mods_list()`): embutido no `.exe` via
+  PyInstaller (`DeltaruneVitaPatcher.spec`, entrada `datas`) e lido em runtime via `resource(...)`;
+  tem um fallback hardcoded idêntico caso o arquivo não seja encontrado.
+- **Web Patcher** (`index.html` na branch `gh-pages`): faz `fetch("mods_list.json")` (cópia gerada a
+  partir do mesmo conteúdo) com o mesmo fallback hardcoded embutido no script.
+- Ambos baixam o `.zip` do mod e extraem **sem transformar nomes de arquivo** — o `.zip` já deve
+  conter `chapterN/data.win` (e, opcionalmente, `chapter0/data.win` para o seletor) prontos para cair
+  em `deltarunevita/mods/<nome>/`. Não há passo de rename `data.win` → `game.droid` em nenhum dos
+  dois patchers (ver [arquitetura.md](arquitetura.md#convenção-de-nome-de-arquivo-datawin-sem-rename-para-gamedroid)).

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,196 @@
+# Arquitetura
+
+Visão dos componentes do DeltaruneVita e como eles se encaixam. Para o histórico narrativo do
+desenvolvimento (o que foi tentado, o que falhou, o que funcionou), veja [PROGRESS.md](PROGRESS.md).
+
+## Visão geral do pipeline
+
+```
+Arquivos oficiais Steam/PC (data.win por capítulo)
+           ↓  scripts/prepare-windows-data.ps1
+data/prepared/deltarune/deltarunevita/  (data.win por capítulo + áudio + mods)
+           ↓  scripts/build-butterscotch-probe.ps1 (Docker + VitaSDK)
+Butterscotch (VM GameMaker) + VitaGL + OpenAL + controles do Vita
+           ↓  vita-elf-create + vita-make-fself + vita-pack-vpk
+Deltarune.vpk (eboot.bin + param.sfo + dados)
+```
+
+Não há dependência de APK Android nem de emulação — os dados são lidos diretamente do formato
+Windows/Steam (`data.win`), copiado como `data.win` por capítulo durante a preparação (sem rename).
+
+## Componentes principais
+
+### `src/butterscotch/` — motor GameMaker (fork vendored)
+
+Fork local de [ButterscotchRunner/Butterscotch](https://github.com/ButterscotchRunner/Butterscotch),
+uma reimplementação open source do runner de bytecode do GameMaker: Studio (compatível com WADs
+versão 8–17, base Undertale v1.08 / GMS 1.4.1804), estendida e corrigida para rodar Deltarune no Vita.
+
+- `src/data_win.c` — leitor de chunks do `data.win`.
+- `src/vm.c`, `src/vm_builtins.c` — VM de bytecode e funções builtin do GML (arquivo mais extenso do
+  projeto; é onde builtins faltantes são implementados conforme aparecem nos logs).
+- `src/runner.c` — loop principal do jogo (step/draw, eventos).
+- `src/instance.c`, `src/spatial_grid.c`, `src/event_table.c`, `src/collision.h` — instâncias de
+  objetos, colisão e agendamento de eventos.
+- `src/gl_common/`, `src/gl_legacy/` — backends de renderização. `gl_legacy_renderer.c` é o renderer
+  usado no Vita (ver seção VitaRenderer abaixo).
+- `src/audio/openal/` — backend de áudio via OpenAL (usado pelo `vita-probe`).
+- `vendor/` — bibliotecas de terceiros vendored (bzip2, md5, sha1, base64, stb, miniaudio, mojoal).
+- Sem subpasta dedicada para Vita — a integração específica de plataforma vive em `src/vita-probe/`.
+
+### `src/vita-probe/` — ponte com o hardware do Vita
+
+Alvo de build ativo (`CMakeLists.txt`, target `PLAYABLE_RUNNER`, ligado por padrão).
+
+- `source/playable_main.c` — entrada principal; inicialização do VitaGL, ajuste de RAM, cache de
+  texturas, tratamento de NPOT, integração com o loop do Butterscotch.
+- `source/vita_settings.c`/`.h` — menu de configurações in-game (vídeo, áudio, controles, PT-BR/EN).
+- `source/vita_video.c`/`.h` — inicialização de vídeo/resolução (`vglInitExtended`).
+- `source/vita_borders.c`/`.h` — bordas/overlay do console por capítulo e área.
+- `source/vitagl_probe.c` — alvo de build separado (`VITAGL_PROBE`, opcional) para diagnóstico
+  isolado do VitaGL, sem o runner completo.
+- `source/main.c` — terceiro alvo, parser mínimo de `data.win` com `debugScreen.c`, sem runner.
+
+O CMake usa `file(GLOB ...)` para juntar as fontes do Butterscotch (`../butterscotch/src/*.c`,
+`gl_common`, `gl_legacy`, `image`, `audio/openal`) com as fontes do `vita-probe` e libs vendored
+(bzip2, md5, sha1, base64), linkando estaticamente contra `libvitaGL.a` e as stubs oficiais da Sony
+(`SceGxm`, `SceCtrl`, `SceDisplay`, `SceAudio`, etc.) e `kubridge`.
+
+Detalhes fixos de build atuais (`src/vita-probe/CMakeLists.txt`):
+- `TITLE ID`: `DLTVITA01`
+- `param.sfo`: `ATTRIBUTE2=12` (necessário para o VPK final funcionar corretamente)
+- Versão de build embutida: ver `PORT_BUILD_VERSION` em `playable_main.c` e `VERSION` no
+  `vita_create_vpk` do CMake — **mantenha os dois sincronizados** ao lançar uma versão.
+
+### VitaRenderer — decisão arquitetural chave
+
+O renderer legado original do Butterscotch usava modo imediato do OpenGL (`glBegin`/`glEnd`), o que
+gera um comando por sprite. O Parameter Buffer do Vita é limitado, e salas cheias de objetos (ex.:
+áreas com muitas árvores) estouravam esse buffer e faziam objetos sumirem.
+
+**Solução**: batching de vértices/índices com buffers pré-alocados e `glDrawElements`/`glDrawArrays`
+em vez de chamadas imediatas por primitiva. Sprites e retângulos foram migrados primeiro; depois
+fontes, tiles, linhas, triângulos e blits de surfaces. Essa migração foi o ponto decisivo que permitiu
+o seletor de capítulos rodar em hardware real (v00.17).
+
+```c
+// Buffer de índices pré-alocado, usado para descarregar milhares de sprites de uma vez na GPU
+static uint16_t vitaIndices[65536];
+glDrawElements(GL_TRIANGLES, vitaIndexCount, GL_UNSIGNED_SHORT, vitaIndices);
+```
+
+### Gestão de memória e cache de texturas
+
+Texturas 2048×2048 vindas do PC enchem a VRAM do Vita rapidamente. Existe um cache com limite
+dinâmico que monitora o uso e despeja páginas de textura antigas quando o limite é atingido
+(`vitaEvictTexturePage()`). O limite global atual do cache de texturas é **192 MiB**.
+
+O pool gráfico do VitaGL foi ajustado ao longo do projeto (começou maior, foi reduzido para liberar
+RAM para o próprio Deltarune) e a stack principal foi aumentada para 4 MiB (o padrão de 256 KiB não
+era suficiente durante a preparação de shaders).
+
+### Suporte a mods e NPOT
+
+Mods (ex.: tradução PT-BR, gerados com UndertaleModTool) costumam ter texturas NPOT (Non-Power-Of-Two,
+ex.: 2000×2000). O hardware do Vita não suporta `GL_REPEAT` para texturas NPOT — a textura fica
+invisível. A correção detecta se a textura é POT e força `GL_CLAMP_TO_EDGE` quando não é:
+
+```c
+bool is_pot = ((w & (w - 1)) == 0) && ((h & (h - 1)) == 0);
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, is_pot ? GL_REPEAT : GL_CLAMP_TO_EDGE);
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, is_pot ? GL_REPEAT : GL_CLAMP_TO_EDGE);
+```
+
+### Troca de capítulos
+
+O seletor usa a função `game_change` do GameMaker. O Butterscotch registra a solicitação, mas quem
+trata a troca é o `main` do `vita-probe`: ele grava o capítulo solicitado, **reinicia o próprio
+eboot** e abre diretamente o `data.win` correspondente. O reinício libera os recursos do seletor
+antes de carregar capítulos que passam de 200 MB — isso evita fragmentação/uso excessivo de memória
+que ocorreria tentando trocar de capítulo sem reiniciar o processo.
+
+### Convenção de nome de arquivo: `data.win` (sem rename para `game.droid`)
+
+Até a v0.63, o pipeline renomeava `data.win` para `game.droid` em cada capítulo (herança da época em
+que o projeto ainda mirava o formato usado pelo port Android/APK). Essa renomeação foi removida: o
+engine (`playable_main.c`, `main.c`, `vitagl_probe.c`) agora procura `chapterN/data.win` diretamente,
+tanto para o carregamento normal do capítulo quanto para o override de mod
+(`mods/<nome>/chapterN/data.win`). Os scripts de preparação (`prepare-windows-data.ps1`,
+`prepare-vita-mods.ps1`) e os patchers (desktop e web) foram atualizados para copiar/extrair os
+arquivos como `data.win`, sem nenhum passo de rename. Isso simplifica o pipeline de mods: o
+conteúdo de um `.zip` de tradução pode ser extraído sem transformação antes de cair em
+`deltarunevita/mods/<nome>/`.
+
+### `third_party/vitaGL-nosplash/`
+
+Fork vendored de [Rinnegatamante/vitaGL](https://github.com/Rinnegatamante/vitaGL) (variante
+"no splash"), com `libvitaGL.a` pré-compilado no repositório. Não é um git submodule — é código
+vendored com `.git` próprio. Compilado via `Makefile` próprio (`NO_SPLASHSCREEN=1 NO_DEBUG=1
+SOFTFP_ABI=1`) como etapa do build Docker.
+
+## Pipeline de dados
+
+### `scripts/prepare-windows-data.ps1` (atual)
+
+1. Lê a instalação Steam/Windows legítima em `SteamFiles/DELTARUNE`.
+2. Copia o `data.win` de cada capítulo (sem rename).
+3. Reestrutura o diretório de áudio (streaming via OpenAL a partir do `ux0:`).
+4. Mescla mods preparados (ex.: PT-BR) se presentes.
+5. Gera a saída em `data/prepared/deltarune/deltarunevita/`.
+
+### `scripts/prepare-vita-mods.ps1`
+
+Empacota mods (ex.: tradução PT-BR de [Teiarruma/deltarune-ptbr](https://github.com/teiarruma/deltarune-ptbr))
+a partir de `mods/PTBR`, copiando `data.win` por capítulo sem rename.
+
+### `scripts/build-butterscotch-probe.ps1` (build atual)
+
+1. Roda um container Docker com a imagem `atamanenko/vitasdk-softfp` (VitaSDK pré-instalado).
+2. Compila `third_party/vitaGL-nosplash` (`libvitaGL.a`).
+3. Roda CMake + `arm-vita-eabi` toolchain sobre `src/vita-probe` (que também compila o
+   Butterscotch via `file(GLOB ...)`).
+4. Linka estaticamente contra as libs oficiais da Sony (`libSceGxm`, `libSceDisplay`, `libSceCtrl`, etc).
+5. `vita-elf-create` converte o `.elf` para `.velf`; `vita-make-fself` assina/empacota como `eboot.bin`.
+6. `vita-pack-vpk` junta `eboot.bin`, `param.sfo`, dados e ícones da LiveArea em
+   `artifacts/current/Deltarune-v<versão>.vpk`.
+
+Os arquivos `Dockerfile`/`compose.yaml`/`compose.debug.yaml` na raiz **não fazem parte** desse
+pipeline — são um stub genérico (`FROM gcc:latest`) não conectado ao build real. O build de VitaSDK
+roda a imagem Docker diretamente via `docker run` dentro do script PowerShell.
+
+## Código legado (não usado no build ativo)
+
+- `src/legacy/soloader/` — abordagem anterior via SoLoader (wrapper de `.so` Android). Ainda referenciado
+  por `scripts/build-deltarune.ps1`, que está desatualizado/não é o pipeline atual.
+- `src/legacy/yoyoloader/` — abordagem ainda mais antiga via YoYo Loader (launcher/patcher de APK).
+  Não referenciado por nenhum script de build atual.
+- `config/yyl.cfg` — configuração residual do YoYo Loader, obsoleta.
+- `tools/yoyoloader-builder/` — ferramentas de empacotamento VPK da era YoYo Loader, git-ignorado,
+  mantido apenas por arqueologia.
+
+Esses caminhos existem por motivos históricos (ver [PROGRESS.md](PROGRESS.md)) e não devem ser usados
+como referência para novo trabalho, exceto se o objetivo for entender por que a abordagem foi abandonada.
+
+## Ferramentas auxiliares (`tools/`)
+
+- `UndertaleModTool/`, `UndertaleModToolCLI/` — GUI e CLI headless do UndertaleModTool, usadas para
+  inspecionar/editar `data.win` durante investigação de bugs e preparação de mods.
+- `nxrune-analysis/` — scripts de análise (`ExportRoomIndex.csx`) para engenharia reversa de GML.
+- `nxrune-chapter-1-5/` — patches xdelta por capítulo + utilitário `xdelta.exe`.
+- `vita-parse-core/` — utilitário Python (`elf.py`, `core.py`) para analisar `psp2core`/ELF ao
+  investigar crashes no hardware real.
+
+## Formato dos dados no Vita
+
+```text
+ux0:data/deltarune/
+├── config.ini
+├── save/
+└── deltarunevita/
+    ├── chapter0/ … chapter5/   (data.win + assets por capítulo)
+    ├── music/
+    ├── borders/
+    └── mods/
+```
+
+Log persistente: `ux0:data/deltarune/deltarunevita/butterscotch-probe.log`.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,40 @@
+# Backlog
+
+Tarefas concretas e pendentes. Itens de direção geral ficam em [roadmap.md](roadmap.md); itens já
+concluídos vão para [changelog.md](changelog.md).
+
+> Convenção: ao concluir um item, mova-o (com a versão/data) para `changelog.md` e remova-o daqui,
+> em vez de apenas marcar como feito.
+
+## Gameplay / runtime
+
+- [ ] Validar entrada completa (não só boot) nos capítulos 1 a 5 no hardware real.
+- [ ] Corrigir builtins do GML ainda não implementados conforme surgirem no
+      `butterscotch-probe.log`.
+- [ ] Revisar surfaces, shaders e efeitos usados durante o gameplay (fora do que já foi validado
+      no seletor e nas primeiras salas).
+- [ ] Testar saves e transições entre capítulos de ponta a ponta.
+
+## Performance / memória
+
+- [ ] Medir uso de memória (RAM + VRAM) nos capítulos maiores, especialmente Capítulo 5.
+- [ ] Revisar thrashing/realocação de texturas remanescente fora do Capítulo 2 (já parcialmente
+      corrigido, ver changelog v0.42).
+
+## Áudio
+
+- [ ] Revisar robustez do streaming de áudio via OpenAL (buffer, sincronização entre faixas).
+
+## Documentação / housekeeping
+
+- [x] Consolidar `docs/` (remover material da era YoYo Loader/SoLoader, manter só o que é válido).
+- [ ] Atualizar `README.md` — a tabela de "Recent Changelog" para em v0.52, mas o build atual está
+      em v0.63 (`PORT_BUILD_VERSION` em `playable_main.c`). Preencher o changelog real do intervalo
+      v0.53–v0.63 (ver [changelog.md](changelog.md)).
+  Nota: manter README e CLAUDE.md sincronizados quanto à versão atual publicada.
+
+## Legado (baixa prioridade)
+
+- [ ] Decidir se `src/legacy/` (soloader, yoyoloader), `config/yyl.cfg` e
+      `tools/yoyoloader-builder/` devem ser removidos do repositório ou mantidos como arquivo
+      histórico permanente.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,73 @@
+# Changelog
+
+Mudanças importantes por versão. Itens de trabalho pendente ficam em [backlog.md](backlog.md); ao
+concluir um item do backlog, registre-o aqui com a versão/data e remova-o de lá.
+
+> Este arquivo é a fonte de verdade para "o que mudou". O `README.md` mantém uma tabela resumida
+> para o usuário final — ao adicionar uma entrada aqui, considere se vale espelhar no README também.
+
+## Não lançado (pós-v0.63, em desenvolvimento)
+
+- **Fim do rename `data.win` → `game.droid`**: engine (`playable_main.c`, `main.c`, `vitagl_probe.c`)
+  passa a procurar `chapterN/data.win` diretamente, tanto no carregamento normal do capítulo quanto
+  no override de mod (`mods/<nome>/chapterN/data.win`). `prepare-windows-data.ps1` e
+  `prepare-vita-mods.ps1` pararam de renomear o arquivo. Motivo: simplificar o pipeline de mods — um
+  `.zip` de tradução pode ser extraído sem transformação. **Requer teste no Vita real antes de
+  release** (carregamento normal e com mod ativo).
+- **Download automático de mods de idioma nos patchers** (desktop e Web Patcher): implementado o
+  fluxo de baixar o `.zip` do mod (4 mirrors: Mediafire, Google Drive, Mega, Archive.org — ordem
+  definida em `mods/mods_list.txt`) e extrair para `deltarunevita/mods/<nome>/`.
+  - Corrigido bug no patcher desktop (`deltarune_vita_patcher.py`): `download_mod()` referenciava
+    `urllib.request` antes do `import` local, o que sempre lançava `UnboundLocalError` e fazia o
+    download automático falhar silenciosamente (caía no aviso genérico de erro).
+  - Corrigido bug no Web Patcher (`index.html`, branch `gh-pages`): o `.zip` baixado (`modZip`) era
+    carregado mas nunca gravado no pacote final gerado — a tradução baixada nunca chegava a
+    `deltarunevita/mods/PTBR/`.
+  - `DeltaruneVitaPatcher.spec` embute `mods/mods_list.txt` no `.exe` via caminho relativo a partir
+    de `SPECPATH` (pasta que contém o `.spec`) — `root.parent.parent.parent`.
+
+## v0.53 – v0.63 (não documentado)
+
+O build atual embute `PORT_BUILD_VERSION "v0.63"` (`src/vita-probe/source/playable_main.c`), mas o
+changelog público (README) só cobre até v0.52. Há pelo menos uma mudança conhecida nesse intervalo
+(migração do diretório de save mixed-case usado em v0.53–v0.56, ver `playable_main.c:357`), mas o
+restante não está registrado. **Pendente**: reconstruir esse intervalo a partir do histórico de
+desenvolvimento disponível, ou passar a registrar cada versão aqui a partir de agora.
+
+## v0.52 e anteriores (histórico, migrado do README)
+
+| Versão | Principais mudanças |
+|---|---|
+| v0.08 | Primeiro VPK de prova de conceito integrando Butterscotch e VitaGL. |
+| v0.08 – v0.22 | Verificações de viabilidade, testes de assets, renderização de texturas e checagens de áudio. |
+| v0.23 | Capítulos 1 e 2 jogáveis pela primeira vez. |
+| v0.24 – v0.34 | Ajustes diversos, correções de bugs e funcionalidades baseadas no runner Android. |
+| v0.35 | Última atualização usando assets derivados do port Android. |
+| v0.36 | Início da migração de dados Android para arquivos nativos Windows/Steam. |
+| v0.37 | Ajustes no pipeline de carregamento do runner Windows, fontes customizadas e áudio externo. |
+| v0.38 | Reversão para uma build estável do VitaGL; correção de diagnóstico de renderização do primeiro frame. |
+| v0.39 | Correção de crash crítico causado pelo overlay de controles touch. |
+| v0.40 | Suporte a música externa, Game Settings redesenhado, menu de seleção de capítulo, cache de texturas e bordas de console. |
+| v0.41 | Streaming de áudio, bordas dinâmicas sensíveis ao contexto, log de quedas de performance. |
+| v0.42 | Correção de caminho de arquivos de áudio e redução de thrashing/recarregamento de texturas no Capítulo 2. |
+| v0.43 | Acesso direto à biblioteca de músicas do Vita; correção de bug de sincronização de faixa no logo do Capítulo 5. |
+| v0.44 | Otimização do atlas de texturas e aumento do buffer de streaming de áudio. |
+| v0.45 | Reformulação da interface do Game Settings. |
+| v0.46 | Correção de regressão que impedia capítulos de iniciar corretamente. |
+| v0.47 | Confirmação adicionada ao Chapter Select, ícone de configurações restaurado, cache de texturas expandido. |
+| v0.48 | Culling de tiles fora de câmera para melhorar performance na área da cidade do Capítulo 5. |
+| v0.49 | Correção de renderização de fonte no Capítulo 5, fade de tela ao carregar save states, primeiro patcher público. |
+| v0.50 | Melhorias em cache de áudio/textura, transições de sala, bordas dinâmicas, padrões de touch, estabilidade dos Capítulos 2/5. |
+| v0.51 | Preparação de texturas gerada pelo patcher, cache de capítulos, mais diagnósticos de performance em runtime. |
+| v0.52 | Carregamento animado de capítulo, capturas Debug Dev, cache de texturas em RAM, otimização de textura font-safe, perfis gráficos Original/Medium/Low selecionáveis. |
+
+## Consolidação da documentação (2026-07-24)
+
+- `docs/` reduzido para conter apenas material válido: `PROGRESS.md` (histórico narrativo) e a nova
+  estrutura (`arquitetura.md`, `roadmap.md`, `backlog.md`, `api.md`, `changelog.md`).
+- Removidos: `BASELINE-INSTRUCTIONS.md`, `DLTVITA-0001-REPORT.md`, `PORT-SOLOADER-TESTE.md`,
+  `INSTALL-PT-BR.txt`, `CONTEXTO_MESTRE_PORTS_PSVITA_PARA_OUTRA_IA.txt` — todos da era YoYo
+  Loader/SoLoader, abordagem abandonada no início do projeto.
+- Conteúdo técnico de `detalhamento_projeto.txt` e `pipeline_build_tecnico.txt` (raiz) incorporado a
+  `docs/arquitetura.md`; os `.txt` originais foram removidos para evitar duplicação.
+- Criado `CLAUDE.md` na raiz como visão geral e convenções do projeto para assistência por IA.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,40 @@
+# Roadmap
+
+Direção de médio/longo prazo do port. Para o histórico de como chegamos até aqui, veja
+[PROGRESS.md](PROGRESS.md). Para tarefas concretas e imediatas, veja [backlog.md](backlog.md).
+
+## Estado atual
+
+Jogável nos cinco capítulos (v0.63 em desenvolvimento; última versão documentada publicamente no
+README é v0.52 — ver [changelog.md](changelog.md) para o que falta documentar entre essas versões).
+Renderer, seletor de capítulos, troca de capítulos via reinício de eboot, cache de texturas, áudio
+via OpenAL, controles físicos e touch, menu de configurações (EN/PT-BR) e suporte a mod de tradução
+já funcionam.
+
+## Direções planejadas
+
+- **Estabilidade de gameplay em todos os capítulos**: validar entrada e progressão completa nos
+  capítulos 1 a 5, não apenas o boot/seletor.
+- **Cobertura de builtins do GML**: implementar builtins do Butterscotch ainda ausentes conforme
+  aparecerem no log (`butterscotch-probe.log`), em vez de tentar prever quais faltam.
+- **Memória em capítulos grandes**: medir e otimizar uso de RAM/VRAM nos capítulos maiores
+  (especialmente Capítulo 5, que já teve trabalho de tile culling).
+- **Áudio**: revisar robustez do streaming OpenAL (sincronização de faixas, thrashing de buffer).
+- **Efeitos visuais e surfaces**: revisar shaders, surfaces e efeitos usados durante o gameplay que
+  ainda não foram validados no hardware real.
+- **Saves e transições**: testar salvamento/carregamento e transições entre capítulos de ponta a ponta.
+- **Localização**: expandir suporte além de PT-BR — o pipeline de dados precisa permitir escolher o
+  idioma do `data.win`/mod no momento da preparação (hoje é majoritariamente PT-BR vs. inglês padrão).
+- **Limpeza de código legado**: eventualmente remover ou arquivar definitivamente `src/legacy/`,
+  `config/yyl.cfg` e `tools/yoyoloader-builder/` depois que não houver mais valor de referência.
+
+## Não-metas
+
+- Não há plano de reintroduzir a abordagem via APK Android/YoYo Loader/SoLoader — essa via foi
+  avaliada e abandonada (ver [PROGRESS.md](PROGRESS.md), seção "Primeiras tentativas").
+- O projeto não distribui e não pretende distribuir assets/dados comerciais de Deltarune.
+
+## Como este documento é mantido
+
+Atualize este roadmap sempre que uma decisão de direção mudar (não apenas quando uma tarefa for
+concluída — isso é o papel do [backlog.md](backlog.md) e do [changelog.md](changelog.md)).

--- a/mods/mods_list.txt
+++ b/mods/mods_list.txt
@@ -1,0 +1,8 @@
+{
+  "PTBR": {
+    "Mediafire": "https://download1472.mediafire.com/wq1sfbskzyhgPzEezrIa5jdDfX9Mut7e3yehfMKMTT5tXxRNA5X_1-Kh9O0LRfl6I_nVWA7RB9ZhyhfAEz2yf6qjBOpUN5bCodQ-juY-TV7E1WysP0VfsJh20Es2vJVICDQMP5VCRqMo65PP9SBEzMASqy0wHF_0Ma69YLJxga4KQUg/4ildqbqja3ehuq2/PTBR.zip",
+    "Google Drive": "https://drive.google.com/uc?export=download&id=1LCT2kD-WQpPQO3dAeIldXBUn2j3c0m9d",
+    "Mega": "https://mega.nz/file/ExcDiC6B#1pqrFjmz2-xaEiQ0SWOaa13N18k9sWevwHWIww21b8Q",
+    "Archive": "https://archive.org/download/ptbr_20260725/PTBR.zip"
+  }
+}

--- a/scripts/prepare-vita-mods.ps1
+++ b/scripts/prepare-vita-mods.ps1
@@ -27,8 +27,8 @@ $launcher = Join-Path $sourcePath 'data.win'
 if (Test-Path -LiteralPath $launcher) {
     $chapter0 = Join-Path $destinationPath 'chapter0'
     New-Item -ItemType Directory -Force -Path $chapter0 | Out-Null
-    Copy-Item -Force -LiteralPath $launcher -Destination (Join-Path $chapter0 'game.droid')
-    Write-Host 'PT-BR chapter0 -> game.droid'
+    Copy-Item -Force -LiteralPath $launcher -Destination $chapter0
+    Write-Host 'PT-BR chapter0 -> data.win'
 }
 
 # Cada data.win traduzido substitui somente o runner data do capitulo. Lang, vid e
@@ -44,12 +44,10 @@ for ($chapter = 1; $chapter -le 5; $chapter++) {
     New-Item -ItemType Directory -Force -Path $targetChapter | Out-Null
     Copy-Item -Recurse -Force -Path (Join-Path $sourceChapter '*') -Destination $targetChapter
 
-    $translatedData = Join-Path $targetChapter 'data.win'
-    if (Test-Path -LiteralPath $translatedData) {
-        Move-Item -Force -LiteralPath $translatedData -Destination (Join-Path $targetChapter 'game.droid')
-        Write-Host "PT-BR chapter$chapter -> game.droid + overlay"
+    if (Test-Path -LiteralPath (Join-Path $targetChapter 'data.win')) {
+        Write-Host "PT-BR chapter$chapter -> data.win + overlay"
     } else {
-        Write-Host "PT-BR chapter$chapter -> overlay sem game.droid"
+        Write-Host "PT-BR chapter$chapter -> overlay sem data.win"
     }
 }
 

--- a/scripts/prepare-windows-data.ps1
+++ b/scripts/prepare-windows-data.ps1
@@ -16,7 +16,7 @@ New-Item -ItemType Directory -Force -Path $Output | Out-Null
 
 $launcher = Join-Path $Output 'chapter0'
 New-Item -ItemType Directory -Force -Path $launcher | Out-Null
-Copy-Item -Force (Join-Path $Source 'data.win') (Join-Path $launcher 'game.droid')
+Copy-Item -Force (Join-Path $Source 'data.win') $launcher
 if (Test-Path (Join-Path $Source 'options.ini')) {
     Copy-Item -Force (Join-Path $Source 'options.ini') $launcher
 }
@@ -25,8 +25,7 @@ for ($chapter = 1; $chapter -le 5; $chapter++) {
     $from = Join-Path $Source "chapter${chapter}_windows"
     $to = Join-Path $Output "chapter$chapter"
     New-Item -ItemType Directory -Force -Path $to | Out-Null
-    Get-ChildItem -Force $from | Where-Object Name -ne 'data.win' | Copy-Item -Destination $to -Recurse -Force
-    Copy-Item -Force (Join-Path $from 'data.win') (Join-Path $to 'game.droid')
+    Get-ChildItem -Force $from | Copy-Item -Destination $to -Recurse -Force
 }
 
 $music = Join-Path $Output 'music'
@@ -44,17 +43,14 @@ New-Item -ItemType Directory -Force -Path $mods | Out-Null
 if (Test-Path (Join-Path $translation 'data.win')) {
     $modLauncher = Join-Path $mods 'chapter0'
     New-Item -ItemType Directory -Force -Path $modLauncher | Out-Null
-    Copy-Item -Force (Join-Path $translation 'data.win') (Join-Path $modLauncher 'game.droid')
+    Copy-Item -Force (Join-Path $translation 'data.win') $modLauncher
 }
 for ($chapter = 1; $chapter -le 5; $chapter++) {
     $from = Join-Path $translation "chapter$chapter"
     if (-not (Test-Path $from)) { continue }
     $to = Join-Path $mods "chapter$chapter"
     New-Item -ItemType Directory -Force -Path $to | Out-Null
-    Get-ChildItem -Force $from | Where-Object Name -ne 'data.win' | Copy-Item -Destination $to -Recurse -Force
-    if (Test-Path (Join-Path $from 'data.win')) {
-        Copy-Item -Force (Join-Path $from 'data.win') (Join-Path $to 'game.droid')
-    }
+    Get-ChildItem -Force $from | Copy-Item -Destination $to -Recurse -Force
 }
 if (Test-Path (Join-Path $translation 'mus')) {
     $modMusic = Join-Path $mods 'music'

--- a/src/vita-probe/source/main.c
+++ b/src/vita-probe/source/main.c
@@ -180,7 +180,7 @@ int main(void) {
     ProbeResult results[6];
     char path[128], line[192];
     for (int i = 0; i < 6; ++i) {
-        snprintf(path, sizeof(path), DATA_DIR "/chapter%d/game.droid", i);
+        snprintf(path, sizeof(path), DATA_DIR "/chapter%d/data.win", i);
         results[i] = probe_file(path);
         snprintf(line, sizeof(line), "CH%d present=%d FORM=%d GEN8=%d size=%llu error=%s",
                  i, results[i].present, results[i].valid_form, results[i].has_gen8,

--- a/src/vita-probe/source/playable_main.c
+++ b/src/vita-probe/source/playable_main.c
@@ -397,12 +397,12 @@ int main(void) {
     int next_chapter = -1;
     char game_path[192];
     char bundle_path[128];
-    snprintf(game_path, sizeof(game_path), DATA_ROOT "chapter%d/game.droid", active_chapter);
+    snprintf(game_path, sizeof(game_path), DATA_ROOT "chapter%d/data.win", active_chapter);
     snprintf(bundle_path, sizeof(bundle_path), DATA_ROOT "chapter%d/", active_chapter);
     if (settings.modIndex > 0 && settings.modIndex < settings.modCount) {
         SceIoStat mod_stat;
         char mod_game[160];
-        snprintf(mod_game, sizeof(mod_game), DATA_ROOT "mods/%s/chapter%d/game.droid", settings.modNames[settings.modIndex], active_chapter);
+        snprintf(mod_game, sizeof(mod_game), DATA_ROOT "mods/%s/chapter%d/data.win", settings.modNames[settings.modIndex], active_chapter);
         if (sceIoGetstat(mod_game, &mod_stat) >= 0) {
             snprintf(game_path, sizeof(game_path), "%s", mod_game);
             log_line("MOD=alternate_game=enabled");

--- a/src/vita-probe/source/vitagl_probe.c
+++ b/src/vita-probe/source/vitagl_probe.c
@@ -92,7 +92,7 @@ int main(void) {
     options.lazyLoadTextures = true;
     options.loadType = DATAWINLOADTYPE_LOAD_PER_CHUNK;
     options.progressCallback = parser_progress;
-    DataWin *dw = DataWin_parse(DATA_DIR "/chapter0/game.droid", options);
+    DataWin *dw = DataWin_parse(DATA_DIR "/chapter0/data.win", options);
     if (!dw || dw->txtr.count == 0) {
         log_line("ERROR=no_txtr_pages");
         sceKernelExitProcess(1);


### PR DESCRIPTION
## Resumo

- Nova estrutura de documentacao: `CLAUDE.md` + `docs/{arquitetura,roadmap,backlog,api,changelog}.md`, substituindo material solto da era YoYo Loader/SoLoader (ja abandonada) que vivia so localmente, nunca commitado.
- Fim do rename `data.win` -> `game.droid`: o engine (`playable_main.c`, `main.c`, `vitagl_probe.c`) passa a procurar `chapterN/data.win` diretamente, no carregamento normal e no override de mod (`mods/<nome>/chapterN/data.win`). `prepare-windows-data.ps1` e `prepare-vita-mods.ps1` pararam de renomear.
- `mods/mods_list.txt`: lista de mirrors de download do mod PTBR (Mediafire, Google Drive, Mega, Archive.org), consumida pelos dois patchers.
- Patcher desktop (`artifacts/Patcher/Build_Patch/src/`, normalmente fora do git por estar em `artifacts/` — os 3 arquivos de codigo foram incluidos manualmente neste PR):
  - Corrige `download_mod()` referenciando `urllib.request` antes do `import` local (sempre lancava `UnboundLocalError`, download automatico da traducao nunca funcionava de fato).
  - Corrige caminho relativo no `.spec` que impedia `mods_list.txt` de ser embutido no `.exe`.
  - Remove conversao `game.droid` -> `data.win` que ficou morta em `build_patch_data.py`.

## Requer teste no Vita real antes de release

- Carregamento normal de capitulo (sem mod).
- Carregamento com mod PT-BR ativo (override `mods/PTBR/chapterN/data.win`).
- Patcher desktop: fluxo completo de geracao + download automatico da traducao.

## Fora deste Pull:

- Fix equivalente no Web Patcher (`index.html`) vai em PR separado contra a branch `gh-pages`, que ainda está em validação.